### PR TITLE
fix react client sdk from dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@notificationapi/react",
-  "version": "1.10.4",
+  "version": "1.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@notificationapi/react",
-      "version": "1.10.4",
+      "version": "1.10.5",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@notificationapi/react",
   "private": false,
-  "version": "1.10.4",
+  "version": "1.10.5",
   "type": "module",
   "overrides": {
     "esbuild": "^0.25.0",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
+import { esmExternalRequirePlugin } from 'rolldown/plugins';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -17,8 +18,14 @@ export default defineConfig({
       entry: resolve(__dirname, 'lib/main.ts'),
       formats: ['es']
     },
-    rollupOptions: {
-      external: ['react', 'react/jsx-runtime'],
+    rolldownOptions: {
+      external: ['react', 'react-dom', 'react/jsx-runtime'],
+      plugins: [
+        esmExternalRequirePlugin({
+          external: [/^react(-dom)?(\/.+)?$/],
+          skipDuplicateCheck: true
+        })
+      ],
       input: Object.fromEntries(
         // https://rollupjs.org/configuration-options/#input
         glob


### PR DESCRIPTION
The last dependabot was a bump from vite 5 to 8 which went from using rollup to rolldown.